### PR TITLE
feat: add groupHistoryOnMention and NapCat config docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,87 @@ openclaw onebot setup
 2. 重启 Gateway：`openclaw gateway restart`
 3. 在 QQ 私聊或群聊中发消息（群聊需 @ 机器人）
 
+## 群聊历史消息上下文
+
+当机器人在群聊中被 @ 时，可以自动获取最近的聊天记录作为上下文，让 AI 更好地理解对话内容。
+
+```json
+{
+  "channels": {
+    "onebot": {
+      "requireMention": true,
+      "groupHistoryOnMention": true,
+      "groupHistoryLimit": 50
+    }
+  }
+}
+```
+
+| 配置项 | 类型 | 默认值 | 说明 |
+|--------|------|--------|------|
+| `requireMention` | boolean | true | 群聊是否需要 @ 才响应 |
+| `groupHistoryOnMention` | boolean | false | 被 @ 时是否获取历史消息 |
+| `groupHistoryLimit` | number | 50 | 获取历史消息的最大数量 |
+
+历史消息会格式化为：
+
+```
+【群聊历史记录】
+[用户A]: 今天天气真好
+[用户B]: 是啊，适合出去玩
+【以上是历史消息】
+
+用户消息: @机器人 你觉得呢？
+```
+
+## NapCat 配置
+
+在 NapCat 的网络配置中添加以下连接：
+
+### 方式 1：反向 WebSocket（推荐）
+
+OpenClaw 作为服务端，NapCat 主动连接：
+
+1. 在 NapCat 网络配置中添加 **WebSocket 客户端**
+2. URL：`ws://openclaw-gateway:18790/onebot/v11/ws`
+   - `openclaw-gateway` 需要在同一个 Docker network 中
+   - 或直接使用 OpenClaw 容器的 IP 地址
+3. Token：与 `openclaw.json` 中的 `accessToken` 保持一致
+
+### 方式 2：正向 WebSocket
+
+OpenClaw 主动连接 NapCat：
+
+1. 在 NapCat 网络配置中添加 **WebSocket 服务器**
+2. 监听端口：`3001`
+3. 在 `openclaw.json` 中配置：
+
+```json
+{
+  "channels": {
+    "onebot": {
+      "enabled": true,
+      "type": "forward-websocket",
+      "host": "napcat",
+      "port": 3001
+    }
+  }
+}
+```
+
+### Docker Network 配置示例
+
+```bash
+# 创建共享网络
+docker network create openclaw-net
+
+# OpenClaw 容器加入网络
+docker network connect openclaw-net openclaw-gateway
+
+# NapCat 容器加入网络
+docker network connect openclaw-net napcat
+```
+
 ## Agent 工具
 
 | 工具 | 说明 |

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -29,6 +29,16 @@
           "enabled": { "type": "boolean", "default": false },
           "message": { "type": "string", "description": "欢迎语模板，{userId} 可替换为新成员 QQ" }
         }
+      },
+      "groupHistoryOnMention": {
+        "type": "boolean",
+        "default": false,
+        "description": "群聊被 @ 时是否获取历史消息作为上下文"
+      },
+      "groupHistoryLimit": {
+        "type": "number",
+        "default": 50,
+        "description": "获取历史消息的最大数量（仅在 groupHistoryOnMention 启用时生效）"
       }
     }
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,6 +141,15 @@ function getRawText(msg: OneBotMessage): string {
     .join("");
 }
 
+/** 从消息段数组中提取文本 */
+function getTextFromMessageContent(message: Array<{ type: string; data?: Record<string, unknown> }> | undefined): string {
+  if (!Array.isArray(message)) return "";
+  return message
+    .filter((m) => m?.type === "text")
+    .map((m) => (m?.data as any)?.text ?? "")
+    .join("");
+}
+
 /** 检查群聊消息是否 @ 了机器人（self_id） */
 function isMentioned(msg: OneBotMessage, selfId: number): boolean {
   const arr = msg.message;
@@ -203,6 +212,19 @@ async function sendGroupMsg(groupId: number, text: string): Promise<void> {
     throw new Error("OneBot WebSocket not connected");
   }
   await sendOneBotAction(w, "send_group_msg", { group_id: groupId, message: text });
+}
+
+/** 获取群聊历史消息 */
+async function getGroupMsgHistory(groupId: number, params?: { message_id?: number; count?: number }): Promise<any[]> {
+  const w = ws;
+  if (!w || w.readyState !== WebSocket.OPEN) {
+    throw new Error("OneBot WebSocket not connected");
+  }
+  const result = await sendOneBotAction(w, "get_group_msg_history", {
+    group_id: groupId,
+    ...params,
+  });
+  return result?.data?.messages ?? [];
 }
 
 /** 发送图片：message 可为 file 路径（file://、http://、base64://）或消息段数组 */
@@ -368,6 +390,42 @@ async function processInboundMessage(api: any, msg: OneBotMessage): Promise<void
       envelope: envelopeOptions,
     }) ?? { content: [{ type: "text", text: messageText }] };
 
+  // 群聊被 @ 时获取历史消息作为上下文
+  const onebotCfg = cfg?.channels?.onebot ?? {};
+  const groupHistoryOnMention = (onebotCfg as any).groupHistoryOnMention ?? false;
+  const groupHistoryLimit = (onebotCfg as any).groupHistoryLimit ?? 50;
+  let historyContext: Array<{ senderId: string; senderName: string; text: string; timestamp: number }> = [];
+
+  if (isGroup && isMentioned(msg, selfId) && groupHistoryOnMention && groupId) {
+    try {
+      const history = await getGroupMsgHistory(groupId, { count: groupHistoryLimit });
+      if (history && history.length > 0) {
+        historyContext = history
+          .filter((m: any) => Number(m.user_id) !== Number(selfId))
+          .reverse()
+          .map((m: any) => {
+            const text = getTextFromMessageContent(m.message);
+            const senderId = String(m.user_id);
+            const senderName = m.sender?.nickname ?? m.sender?.card ?? senderId;
+            return { senderId, senderName, text, timestamp: m.time };
+          });
+        api.logger?.info?.(`[onebot] fetched ${historyContext.length} history messages for group ${groupId}`);
+      }
+    } catch (e: any) {
+      api.logger?.warn?.(`[onebot] failed to fetch group history: ${e?.message}`);
+    }
+  }
+
+  // 如果有历史消息，拼接到 RawBody
+  let finalRawBody = messageText;
+  if (historyContext.length > 0) {
+    const historyText = historyContext
+      .map((h) => `[${h.senderName}]: ${h.text}`)
+      .join("\n");
+    finalRawBody = `【群聊历史记录】\n${historyText}\n【以上是历史消息】\n\n用户消息: ${messageText}`;
+    api.logger?.info?.(`[onebot] history context prepended, total ${finalRawBody.length} chars`);
+  }
+
   const body = buildPendingHistoryContextFromMap
     ? buildPendingHistoryContextFromMap({
         historyMap: sessionHistories,
@@ -403,7 +461,7 @@ async function processInboundMessage(api: any, msg: OneBotMessage): Promise<void
 
   const ctxPayload = {
     Body: body,
-    RawBody: messageText,
+    RawBody: finalRawBody,
     From: isGroup ? `onebot:group:${groupId}` : `onebot:${userId}`,
     To: `onebot:${userId}`,
     SessionKey: sessionId,


### PR DESCRIPTION
## 功能

### 1. 群聊历史消息上下文

当机器人在群聊中被 @ 时，可以自动获取最近的聊天记录作为上下文，让 AI 更好地理解对话内容。

**新增配置项：**
- `groupHistoryOnMention`: 群聊被 @ 时是否获取历史消息（默认 false）
- `groupHistoryLimit`: 获取历史消息的最大数量（默认 50）

**使用示例：**
```json
{
  "channels": {
    "onebot": {
      "requireMention": true,
      "groupHistoryOnMention": true,
      "groupHistoryLimit": 50
    }
  }
}
```

**历史消息格式：**
```
【群聊历史记录】
[用户A]: 今天天气真好
[用户B]: 是啊，适合出去玩
【以上是历史消息】

用户消息: @机器人 你觉得呢？
```

### 2. NapCat 配置指南

添加了详细的 NapCat 配置说明：
- 反向 WebSocket 配置（推荐）
- 正向 WebSocket 配置
- Docker Network 配置示例

## 修改文件

- `src/index.ts`: 添加 `getGroupMsgHistory` 函数和 `getTextFromMessageContent` 辅助函数
- `openclaw.plugin.json`: 添加 `groupHistoryOnMention` 和 `groupHistoryLimit` 配置项
- `README.md`: 添加功能文档和 NapCat 配置指南

## 测试

已在实际 NapCat 环境中测试通过。