### PR TITLE
Fix cross-host OneBot image sending

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1,7 +1,9 @@
 /**
  * OneBot WebSocket 连接与 API 调用
  *
- * 图片消息：网络 URL 会先下载到本地再发送（兼容 Lagrange.Core retcode 1200），
+ * 图片消息：
+ * - 本机回环连接时：网络 URL 会先下载到本地再发送（兼容部分实现的 retcode 1200）
+ * - 跨机器连接时：本地文件会自动转成 base64://，避免把宿主机绝对路径发给远端 OneBot
  * 并定期清理临时文件。
  */
 
@@ -10,7 +12,7 @@ import WebSocket from "ws";
 import { createServer } from "http";
 import https from "https";
 import http from "http";
-import { writeFileSync, mkdirSync, readdirSync, statSync, unlinkSync } from "fs";
+import { writeFileSync, mkdirSync, readdirSync, readFileSync, statSync, unlinkSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import type { OneBotAccountConfig } from "./types.js";
@@ -102,6 +104,56 @@ async function resolveImageToLocalPath(image: string): Promise<string> {
     return trimmed.replace(/\\/g, "/");
 }
 
+async function resolveImageToBuffer(image: string): Promise<Buffer> {
+    const trimmed = image?.trim();
+    if (!trimmed) throw new Error("Empty image");
+
+    if (/^https?:\/\//i.test(trimmed)) {
+        return downloadUrl(trimmed);
+    }
+    if (trimmed.startsWith("base64://")) {
+        return Buffer.from(trimmed.slice(9), "base64");
+    }
+    if (trimmed.startsWith("file://")) {
+        return readFileSync(trimmed.slice(7));
+    }
+    return readFileSync(trimmed);
+}
+
+function normalizePeerHost(host: string | undefined | null): string {
+    const trimmed = String(host ?? "").trim().toLowerCase();
+    if (!trimmed) return "";
+    const unwrapped = trimmed.replace(/^\[/, "").replace(/\]$/, "");
+    return unwrapped.startsWith("::ffff:") ? unwrapped.slice(7) : unwrapped;
+}
+
+function isLoopbackHost(host: string | undefined | null): boolean {
+    const normalized = normalizePeerHost(host);
+    return normalized === "127.0.0.1" || normalized === "::1" || normalized === "localhost";
+}
+
+function getSocketPeerHost(socket: WebSocket, getConfig?: () => OneBotAccountConfig | null): string {
+    const peerHost = (socket as OneBotSocketWithPeer).__onebotPeerHost;
+    if (peerHost) return peerHost;
+    return getConfig?.()?.host ?? "";
+}
+
+function shouldEncodeImageAsBase64(socket: WebSocket, getConfig?: () => OneBotAccountConfig | null): boolean {
+    const peerHost = getSocketPeerHost(socket, getConfig);
+    return !!peerHost && !isLoopbackHost(peerHost);
+}
+
+async function resolveImageFileForSend(
+    image: string,
+    socket: WebSocket,
+    getConfig?: () => OneBotAccountConfig | null
+): Promise<string> {
+    if (shouldEncodeImageAsBase64(socket, getConfig)) {
+        return `base64://${(await resolveImageToBuffer(image)).toString("base64")}`;
+    }
+    return resolveImageToLocalPath(image);
+}
+
 /** 启动临时图片定期清理（每小时执行一次） */
 export function startImageTempCleanup(): void {
     stopImageTempCleanup();
@@ -125,6 +177,8 @@ let echoCounter = 0;
 
 let connectionReadyResolve: (() => void) | null = null;
 const connectionReadyPromise = new Promise<void>((r) => { connectionReadyResolve = r; });
+
+type OneBotSocketWithPeer = WebSocket & { __onebotPeerHost?: string };
 
 function nextEcho(): string {
     return `onebot-${Date.now()}-${++echoCounter}`;
@@ -311,7 +365,7 @@ export async function sendGroupImage(
     log.info?.(`222[onebot] sendGroupImage entry: groupId=${groupId} image=${image?.slice?.(0, 80) ?? ""}`);
 
     try {
-        const filePath = image.startsWith("[") ? null : await resolveImageToLocalPath(image);
+        const filePath = image.startsWith("[") ? null : await resolveImageFileForSend(image, socket, getConfig);
         const seg = image.startsWith("[")
             ? JSON.parse(image)
             : [{ type: "image", data: { file: filePath! } }];
@@ -392,7 +446,7 @@ export async function sendPrivateImage(
     });
     log.info?.(`[onebot] sendPrivateImage entry: userId=${userId} image=${image?.slice?.(0, 80) ?? ""}`);
     const socket = getConfig ? await ensureConnection(getConfig) : await waitForConnection();
-    const filePath = image.startsWith("[") ? null : await resolveImageToLocalPath(image);
+    const filePath = image.startsWith("[") ? null : await resolveImageFileForSend(image, socket, getConfig);
     const seg = image.startsWith("[")
         ? JSON.parse(image)
         : [{ type: "image", data: { file: filePath! } }];
@@ -672,6 +726,7 @@ export async function connectForward(config: OneBotAccountConfig): Promise<WebSo
         w.on("open", () => resolve());
         w.on("error", reject);
     });
+    (w as OneBotSocketWithPeer).__onebotPeerHost = config.host;
     return w;
 }
 
@@ -689,7 +744,8 @@ export async function createServerAndWait(config: OneBotAccountConfig): Promise<
     wsServer = wss as any;
 
     return new Promise((resolve) => {
-        wss.on("connection", (socket: WebSocket) => {
+        wss.on("connection", (socket: WebSocket, req) => {
+            (socket as OneBotSocketWithPeer).__onebotPeerHost = req.socket.remoteAddress ?? undefined;
             resolve(socket as WebSocket);
         });
     });


### PR DESCRIPTION
This fixes image sending failures when the OneBot server is running on a different host.

Previously, when the OneBot connection target was not `127.0.0.1`, the plugin could still send a local absolute file path as `image.file`. That path only exists on the sender machine, so the remote OneBot server could not read it, which could result in failed image delivery or `retcode=1200`.

This change adds peer host awareness to image sending:
- If the connection target is a local loopback address (`127.0.0.1`, `localhost`, or `::1`), the existing local file path behavior is preserved.
- If the connection target is not local, the image is automatically encoded as `base64://` before sending, so the remote OneBot server does not need access to the sender’s filesystem.
- This works for both forward WebSocket and reverse WebSocket modes.

As a result, image sending is now more reliable for cross-host deployments, reverse proxy setups, and remote OneBot services.


描述：
修复跨主机场景下 OneBot 图片发送失败的问题。

此前当 OneBot 服务不在 `127.0.0.1` 本机时，插件仍会把本地图片绝对路径直接作为 `image.file` 发送给远端 OneBot，导致远端无法访问宿主机文件，出现发送失败或 `retcode=1200`。

这次修改增加了对连接对端地址的识别：
- 当连接目标是本机回环地址（如 `127.0.0.1` / `localhost` / `::1`）时，继续沿用本地文件路径发送。
- 当连接目标是非本机地址时，自动将本地图片内容编码为 `base64://` 后再发送，避免远端依赖本地文件系统路径。
- 同时兼容正向 WebSocket 和反向 WebSocket 连接方式。

这样可以保证在跨机器部署、反向代理或远端 OneBot 服务场景下，图片消息能够以更可靠的方式发送。


人话：
非`127.0.0.1` ip，对图片进行base64编码传送图片，而不是发送绝对路径。

