### PR TITLE
feat(inbound): 新增 replyWhenWhitelistDenied 配置用于开关权限不足提示

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kirigaya/openclaw-onebot",
-  "version": "1.0.7",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kirigaya/openclaw-onebot",
-      "version": "1.0.7",
+      "version": "1.0.9",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.0.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -143,3 +143,9 @@ export function getTriggerMode(cfg: any): "prefix" | "contains" {
   if (v === "contains") return "contains";
   return "prefix"; // 默认为前缀匹配
 }
+
+/** 是否在用户不在白名单时回复“权限不足”，默认 true */
+export function getReplyWhenWhitelistDenied(cfg: any): boolean {
+  const v = cfg?.channels?.onebot?.replyWhenWhitelistDenied;
+  return v === undefined ? true : Boolean(v);
+}

--- a/src/handlers/process-inbound.ts
+++ b/src/handlers/process-inbound.ts
@@ -21,6 +21,7 @@ import {
     getNormalModeFlushChars,
     getTriggerKeywords,
     getTriggerMode,
+    getReplyWhenWhitelistDenied,
 } from "../config.js";
 import { markdownToPlain, collapseDoubleNewlines } from "../markdown.js";
 import { markdownToImage } from "../og-image.js";
@@ -49,10 +50,10 @@ export const sessionHistories = new Map<string, Array<{ sender: string; body: st
  */
 function checkTriggerKeyword(text: string, keywords: string[], mode: "prefix" | "contains"): boolean {
     if (!text || keywords.length === 0) return false;
-    
+
     for (const keyword of keywords) {
         if (!keyword) continue;
-        
+
         if (mode === "prefix") {
             // 前缀匹配：消息以关键词开头（忽略前导空格）
             const trimmedText = text.trimStart();
@@ -141,7 +142,7 @@ export async function processInboundMessage(api: any, msg: OneBotMessage): Promi
     // 触发检查逻辑
     if (isGroup) {
         const isAtMentioned = isMentioned(msg, selfId);
-        
+
         if (requireMention) {
             // 传统模式：必须 @ 才响应
             if (!isAtMentioned) {
@@ -155,7 +156,7 @@ export async function processInboundMessage(api: any, msg: OneBotMessage): Promi
                 const triggerMode = getTriggerMode(cfg);
                 const textFromMsg = getTextFromSegments(msg).trim() || messageText.trim();
                 const matched = checkTriggerKeyword(textFromMsg, triggerKeywords, triggerMode);
-                
+
                 if (!matched) {
                     api.logger?.info?.(`[onebot] ignoring group message, no trigger keyword matched`);
                     return;
@@ -183,20 +184,22 @@ export async function processInboundMessage(api: any, msg: OneBotMessage): Promi
     }
 
     const userId = msg.user_id!;
-    
+
     // 白名单检查
     const whitelist = getWhitelistUserIds(cfg);
     if (whitelist.length > 0 && !whitelist.includes(Number(userId))) {
-        const denyMsg = "权限不足，请向管理员申请权限";
-        const getConfig = () => getOneBotConfig(api);
-        try {
-            if (msg.message_type === "group" && msg.group_id) await sendGroupMsg(msg.group_id, denyMsg, getConfig);
-            else await sendPrivateMsg(userId, denyMsg, getConfig);
-        } catch (_) {}
+        if (getReplyWhenWhitelistDenied(cfg)) {
+            const denyMsg = "权限不足，请向管理员申请权限";
+            const getConfig = () => getOneBotConfig(api);
+            try {
+                if (msg.message_type === "group" && msg.group_id) await sendGroupMsg(msg.group_id, denyMsg, getConfig);
+                else await sendPrivateMsg(userId, denyMsg, getConfig);
+            } catch (_) { }
+        }
         api.logger?.info?.(`[onebot] user ${userId} not in whitelist, denied`);
         return;
     }
-    
+
     // 黑名单检查
     const blacklist = getBlacklistUserIds(cfg);
     if (blacklist.length > 0 && blacklist.includes(Number(userId))) {
@@ -214,7 +217,7 @@ export async function processInboundMessage(api: any, msg: OneBotMessage): Promi
         channel: "onebot",
         accountId: config.accountId ?? "default",
     }) ?? { agentId: "main" };
-    
+
     // 修复构造符合 OpenClaw 规范的全局 SessionKey格式必须为 agent:{agentId}:{channel}:{type}:{id}，否则下方的dispatchReplyWithBufferedBlockDispatcher会触发自动兜底机制，直接在 main 代理下“克隆”出一个一模一样的会话，导致多agent配置达不到效果
     const sessionId = `agent:${route.agentId}:${tempSessionId}`;
     const storePath =


### PR DESCRIPTION
- 在 src/config.ts 中新增了 getReplyWhenWhitelistDenied 读取开关配置，默认为 true。
- 在 src/handlers/process-inbound.ts 的白名单拦截逻辑中接入了该配置。
- 允许管理员在 openclaw.json 中配置 replyWhenWhitelistDenied: false，使得未授权用户触发机器人时仅静默拦截，不再回复“权限不足”的提示消息。