### PR TITLE
bugfix: 修复 normal 模式下机器人偶发"已读不回"的问题

### DIFF
--- a/src/handlers/process-inbound.ts
+++ b/src/handlers/process-inbound.ts
@@ -697,6 +697,9 @@ export async function processInboundMessage(api: any, msg: OneBotMessage): Promi
         });
     } catch (err: any) {
         await clearEmojiReaction();
+        // 异常时清空缓冲，避免 finally 补发半截正文后再发错误消息
+        normalModeBufferedText = "";
+        normalModeBufferedRawText = "";
         api.logger?.error?.(`[onebot] dispatch failed: ${err?.message}`);
         try {
             const { userId: uid, groupId: gid, isGroup: ig } = (ctxPayload as any)._onebot || {};
@@ -704,6 +707,20 @@ export async function processInboundMessage(api: any, msg: OneBotMessage): Promi
             else if (uid) await sendPrivateMsg(uid, `处理失败: ${err?.message?.slice(0, 80) || "未知错误"}`);
         } catch (_) { }
     } finally {
+        // 补发缓冲池中残留的文本（引擎未发送 final 帧时会走到这里）
+        if (hasBufferedNormalModeText()) {
+            try {
+                const { userId: uid, groupId: gid, isGroup: ig } = (ctxPayload as any)._onebot || {};
+                const sessionKey = String((ctxPayload as any).SessionKey ?? sessionId);
+                const groupMatch = sessionKey.match(/^onebot:group:(\d+)$/i);
+                const effectiveIsGroup = groupMatch != null || Boolean(ig);
+                const effectiveGroupId = (groupMatch ? parseInt(groupMatch[1], 10) : undefined) ?? gid;
+                queueNormalModeFlush(() => flushBufferedNormalModeText(effectiveIsGroup, effectiveGroupId, uid));
+                await normalModeFlushChain;
+            } catch (e: any) {
+                api.logger?.error?.(`[onebot] finally flush failed: ${e?.message ?? e}`);
+            }
+        }
         clearNormalModeFlushTimer();
         setForwardSuppressDelivery(false);
         setActiveReplySelfId(null);


### PR DESCRIPTION
表现现象：
在 LLM 回复内容较短（比如一句话 + 一个 emoji）时大概率出现，回复较长或恰好以句号/问号等标点结尾时又偶尔正常。
根因：
当 LLM 生成内容很短时，引擎可能不发送 kind=final 结束帧，
导致缓冲池中的回复文本无法被刷出。finally 块中的
clearNormalModeFlushTimer() 又会立即取消定时器，彻底丢弃缓冲。

修复：
- finally: 在清除定时器前检查缓冲池，若有残留文本则主动刷出并等待发送完成
- catch: 异常时立即清空缓冲池，避免 finally 补发半截正文后再发错误消息