### PR TITLE
feat: 会话上下文中显示channel用户昵称

### DIFF
--- a/src/handlers/process-inbound.ts
+++ b/src/handlers/process-inbound.ts
@@ -697,6 +697,9 @@ export async function processInboundMessage(api: any, msg: OneBotMessage): Promi
         });
     } catch (err: any) {
         await clearEmojiReaction();
+        // 异常时清空缓冲，避免 finally 补发半截正文后再发错误消息
+        normalModeBufferedText = "";
+        normalModeBufferedRawText = "";
         api.logger?.error?.(`[onebot] dispatch failed: ${err?.message}`);
         try {
             const { userId: uid, groupId: gid, isGroup: ig } = (ctxPayload as any)._onebot || {};
@@ -704,6 +707,20 @@ export async function processInboundMessage(api: any, msg: OneBotMessage): Promi
             else if (uid) await sendPrivateMsg(uid, `处理失败: ${err?.message?.slice(0, 80) || "未知错误"}`);
         } catch (_) { }
     } finally {
+        // 补发缓冲池中残留的文本（引擎未发送 final 帧时会走到这里）
+        if (hasBufferedNormalModeText()) {
+            try {
+                const { userId: uid, groupId: gid, isGroup: ig } = (ctxPayload as any)._onebot || {};
+                const sessionKey = String((ctxPayload as any).SessionKey ?? sessionId);
+                const groupMatch = sessionKey.match(/^onebot:group:(\d+)$/i);
+                const effectiveIsGroup = groupMatch != null || Boolean(ig);
+                const effectiveGroupId = (groupMatch ? parseInt(groupMatch[1], 10) : undefined) ?? gid;
+                queueNormalModeFlush(() => flushBufferedNormalModeText(effectiveIsGroup, effectiveGroupId, uid));
+                await normalModeFlushChain;
+            } catch (e: any) {
+                api.logger?.error?.(`[onebot] finally flush failed: ${e?.message ?? e}`);
+            }
+        }
         clearNormalModeFlushTimer();
         setForwardSuppressDelivery(false);
         setActiveReplySelfId(null);

--- a/src/handlers/process-inbound.ts
+++ b/src/handlers/process-inbound.ts
@@ -227,7 +227,11 @@ export async function processInboundMessage(api: any, msg: OneBotMessage): Promi
 
     const envelopeOptions = runtime.channel.reply?.resolveEnvelopeFormatOptions?.(cfg) ?? {};
     const chatType = isGroup ? "group" : "direct";
-    const fromLabel = String(userId);
+    // 优先使用群名片(card)，其次是昵称(nickname)，都没有则为空串
+    const senderNickname = (isGroup ? msg.sender?.card?.trim() : undefined)
+        || msg.sender?.nickname?.trim()
+        || "";
+    const fromLabel = senderNickname || String(userId);
 
     // 添加日志：打印插件接收到的原始消息内容
     api.logger?.info?.(`[onebot] received message from user ${userId}: "${messageText}"`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,11 @@ export interface OneBotMessage {
   raw_message?: string;
   self_id?: number;
   time?: number;
-  notice_type?: string;
+  sender?: {
+    user_id?: number;
+    nickname?: string;
+    card?: string;
+  };
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
- 在 OneBotMessage 接口新增 sender 字段（nickname、card）
- 入站消息处理时从 msg.sender 提取群名片或昵称作为 fromLabel
- 群聊优先使用群名片(card)，其次昵称(nickname)，无则降级为纯 ID
