### PR TITLE
feat: 添加 LLM 到 OneBot 消息下发链路的追踪日志

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -201,18 +201,23 @@ function sendOneBotAction(wsocket: WebSocket, action: string, params: Record<str
     const echo = nextEcho();
     const payload = { action, params, echo };
 
+    // Log the initiation of the action with basic target info
+    const targetInfo = params.group_id ? `group=${params.group_id}` : (params.user_id ? `user=${params.user_id}` : "");
+    log.info?.(`[onebot-trace] sendOneBotAction action=${action} echo=${echo} ${targetInfo}`);
+
     return new Promise((resolve, reject) => {
         const timeout = setTimeout(() => {
             pendingEcho.delete(echo);
-            log.warn?.(`[onebot] sendOneBotAction ${action} timeout`);
-            reject(new Error(`OneBot action ${action} timeout`));
+            log.warn?.(`[onebot-trace] sendOneBotAction ${action} timeout for echo=${echo}, ws.readyState=${wsocket.readyState}`);
+            reject(new Error(`OneBot action ${action} timeout (echo=${echo}, ws.readyState=${wsocket.readyState})`));
         }, 15000);
 
         pendingEcho.set(echo, {
             resolve: (v) => {
                 clearTimeout(timeout);
                 pendingEcho.delete(echo);
-                if (v?.retcode !== 0) log.warn?.(`[onebot] sendOneBotAction ${action} retcode=${v?.retcode} msg=${v?.msg ?? ""}`);
+                log.info?.(`[onebot-trace] echo ${echo} resolved with retcode=${v?.retcode} message_id=${v?.data?.message_id ?? "unknown"}`);
+                if (v?.retcode !== 0) log.warn?.(`[onebot-trace] sendOneBotAction ${action} retcode=${v?.retcode} msg=${v?.msg ?? ""}`);
                 resolve(v);
             },
         });
@@ -221,6 +226,7 @@ function sendOneBotAction(wsocket: WebSocket, action: string, params: Record<str
             if (err) {
                 pendingEcho.delete(echo);
                 clearTimeout(timeout);
+                log.warn?.(`[onebot-trace] sendOneBotAction ${action} wsocket.send error for echo=${echo}: ${err.message}`);
                 reject(err);
             }
         });
@@ -461,13 +467,13 @@ export async function sendPrivateImage(
 }
 
 export async function uploadGroupFile(
-    groupId: number, 
-    file: string, 
+    groupId: number,
+    file: string,
     name: string,
     getConfig?: () => OneBotAccountConfig | null
 ): Promise<void> {
-    const socket = getConfig 
-        ? await ensureConnection(getConfig) 
+    const socket = getConfig
+        ? await ensureConnection(getConfig)
         : await waitForConnection();
     const res = await sendOneBotAction(socket, "upload_group_file", { group_id: groupId, file, name });
     if (res?.retcode !== 0) {
@@ -476,13 +482,13 @@ export async function uploadGroupFile(
 }
 
 export async function uploadPrivateFile(
-    userId: number, 
-    file: string, 
+    userId: number,
+    file: string,
     name: string,
     getConfig?: () => OneBotAccountConfig | null
 ): Promise<void> {
-    const socket = getConfig 
-        ? await ensureConnection(getConfig) 
+    const socket = getConfig
+        ? await ensureConnection(getConfig)
         : await waitForConnection();
     const res = await sendOneBotAction(socket, "upload_private_file", { user_id: userId, file, name });
     if (res?.retcode !== 0) {

--- a/src/handlers/process-inbound.ts
+++ b/src/handlers/process-inbound.ts
@@ -346,11 +346,18 @@ export async function processInboundMessage(api: any, msg: OneBotMessage): Promi
         }
     }
 
-    api.logger?.info?.(`[onebot] dispatching message for session ${sessionId}`);
+    const traceId = `trace-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    const traceLog = {
+        info: (m: string) => api.logger?.info?.(`[${traceId}] ${m}`),
+        warn: (m: string) => api.logger?.warn?.(`[${traceId}] ${m}`),
+        error: (m: string) => api.logger?.error?.(`[${traceId}] ${m}`)
+    };
+
+    traceLog.info(`dispatching message for session ${sessionId}`);
 
     const longMessageMode = (onebotCfg.longMessageMode as "normal" | "og_image" | "forward") ?? "normal";
     const longMessageThreshold = (onebotCfg.longMessageThreshold as number) ?? 300;
-    api.logger?.info?.(`[onebot] longMessageMode=${longMessageMode}, threshold=${longMessageThreshold}`);
+    traceLog.info(`longMessageMode=${longMessageMode}, threshold=${longMessageThreshold}`);
     const normalModeFlushIntervalMs = getNormalModeFlushIntervalMs(cfg);
     const normalModeFlushChars = getNormalModeFlushChars(cfg);
 
@@ -366,14 +373,16 @@ export async function processInboundMessage(api: any, msg: OneBotMessage): Promi
     let normalModeBufferedRawText = "";
     let normalModeFlushTimer: ReturnType<typeof setTimeout> | null = null;
     let normalModeFlushChain: Promise<void> = Promise.resolve();
+    let receivedFinal = false;
 
     const getConfig = () => getOneBotConfig(api);
 
     const onReplySessionEnd = onebotCfg.onReplySessionEnd as string | ((ctx: ReplySessionContext) => void | Promise<void>) | undefined;
     const normalModePunctuationFlushMinChars = 24;
 
-    const clearNormalModeFlushTimer = () => {
+    const clearNormalModeFlushTimer = (reason: string = "unknown") => {
         if (normalModeFlushTimer) {
+            traceLog.info(`clearNormalModeFlushTimer: clearing timer, reason=${reason}`);
             clearTimeout(normalModeFlushTimer);
             normalModeFlushTimer = null;
         }
@@ -385,7 +394,7 @@ export async function processInboundMessage(api: any, msg: OneBotMessage): Promi
         normalModeFlushChain = normalModeFlushChain
             .then(action)
             .catch((e: any) => {
-                api.logger?.error?.(`[onebot] normal-mode flush failed: ${e?.message ?? e}`);
+                traceLog.error(`normal-mode flush failed: ${e?.message ?? e}`);
             });
         return normalModeFlushChain;
     };
@@ -412,11 +421,12 @@ export async function processInboundMessage(api: any, msg: OneBotMessage): Promi
         effectiveGroupId: number | undefined,
         uid: number | undefined
     ): Promise<void> => {
-        clearNormalModeFlushTimer();
+        clearNormalModeFlushTimer("flushBufferedNormalModeText");
         if (!hasBufferedNormalModeText()) return;
 
         const text = normalModeBufferedText;
         const rawText = normalModeBufferedRawText;
+        traceLog.info(`flushBufferedNormalModeText: textLen=${text.length}, textPreview="${text.slice(0, 30).replace(/\n/g, '\\n')}"`);
         normalModeBufferedText = "";
         normalModeBufferedRawText = "";
 
@@ -434,7 +444,9 @@ export async function processInboundMessage(api: any, msg: OneBotMessage): Promi
         uid: number | undefined
     ) => {
         if (normalModeFlushTimer) return;
+        traceLog.info(`scheduleNormalModeFlush: scheduled (interval=${normalModeFlushIntervalMs}ms)`);
         normalModeFlushTimer = setTimeout(() => {
+            traceLog.info(`scheduleNormalModeFlush: timer triggered`);
             void queueNormalModeFlush(() => flushBufferedNormalModeText(effectiveIsGroup, effectiveGroupId, uid));
         }, normalModeFlushIntervalMs);
     };
@@ -471,6 +483,13 @@ export async function processInboundMessage(api: any, msg: OneBotMessage): Promi
                     const replyText = typeof p === "string" ? p : (p?.text ?? p?.body ?? "");
                     const mediaUrl = typeof p === "string" ? undefined : (p?.mediaUrl ?? p?.mediaUrls?.[0]);
                     const trimmed = (replyText || "").trim();
+
+                    traceLog.info(`deliver entry: kind=${info.kind}, textLen=${replyText.length}, mediaUrl=${!!mediaUrl}, deliveredChunks=${deliveredChunks.length}`);
+
+                    if (info.kind === "final") {
+                        receivedFinal = true;
+                    }
+
                     if ((!trimmed || trimmed === "NO_REPLY" || trimmed.endsWith("NO_REPLY")) && !mediaUrl) return;
 
                     const { userId: uid, groupId: gid, isGroup: ig } = (ctxPayload as any)._onebot || {};
@@ -541,7 +560,7 @@ export async function processInboundMessage(api: any, msg: OneBotMessage): Promi
                             const isLong = totalLen > longMessageThreshold;
                             const isIncrementalLong = incrementalLen > longMessageThreshold;
                             const isIncremental = lastSentCount > 0;
-                            api.logger?.info?.(`[onebot] final check: totalLen=${totalLen}, threshold=${longMessageThreshold}, isLong=${isLong}, isIncremental=${isIncremental}, deliveredChunks=${deliveredChunks.length}`);
+                            traceLog.info(`final check: totalLen=${totalLen}, threshold=${longMessageThreshold}, isLong=${isLong}, isIncremental=${isIncremental}, deliveredChunks=${deliveredChunks.length}`);
 
                             if (isIncremental) {
                                 setForwardSuppressDelivery(false);
@@ -605,9 +624,9 @@ export async function processInboundMessage(api: any, msg: OneBotMessage): Promi
                                     }
                                 }
                             } else if (!shouldSendNow && (longMessageMode === "og_image" || longMessageMode === "forward")) {
-                                api.logger?.info?.(`[onebot] checking og_image: isLong=${isLong}, mode=${longMessageMode}`);
+                                traceLog.info(`checking og_image: isLong=${isLong}, mode=${longMessageMode}`);
                                 if (isLong && longMessageMode === "og_image") {
-                                    api.logger?.info?.(`[onebot] triggering og_image for ${totalLen} chars`);
+                                    traceLog.info(`triggering og_image for ${totalLen} chars`);
                                     const fullRaw = deliveredChunks.map((c) => c.rawText ?? c.text ?? "").join("\n\n");
                                     if (fullRaw.trim()) {
                                         try {
@@ -689,28 +708,30 @@ export async function processInboundMessage(api: any, msg: OneBotMessage): Promi
                             }
                         }
                     } catch (e: any) {
-                        api.logger?.error?.(`[onebot] deliver failed: ${e?.message}`);
+                        traceLog.error(`deliver failed: ${e?.message}`);
                     }
                 },
                 onError: async (err: any, info: any) => {
-                    api.logger?.error?.(`[onebot] ${info?.kind} reply failed: ${err}`);
+                    traceLog.error(`${info?.kind} reply failed: ${err}`);
                     await clearEmojiReaction();
                 },
             },
             replyOptions: { disableBlockStreaming: longMessageMode !== "normal" },
         });
+        traceLog.info(`dispatchReplyWithBufferedBlockDispatcher returned successfully.`);
     } catch (err: any) {
         await clearEmojiReaction();
         // 异常时清空缓冲，避免 finally 补发半截正文后再发错误消息
+        traceLog.error(`dispatch catch block: err=${err?.message}, receivedFinal=${receivedFinal}, chunkIndex=${chunkIndex}`);
         normalModeBufferedText = "";
         normalModeBufferedRawText = "";
-        api.logger?.error?.(`[onebot] dispatch failed: ${err?.message}`);
         try {
             const { userId: uid, groupId: gid, isGroup: ig } = (ctxPayload as any)._onebot || {};
             if (ig && gid) await sendGroupMsg(gid, `处理失败: ${err?.message?.slice(0, 80) || "未知错误"}`);
             else if (uid) await sendPrivateMsg(uid, `处理失败: ${err?.message?.slice(0, 80) || "未知错误"}`);
         } catch (_) { }
     } finally {
+        traceLog.info(`dispatch finally block: receivedFinal=${receivedFinal}, hasBuffered=${hasBufferedNormalModeText()}, bufferLen=${normalModeBufferedText.length}, hasTimer=${!!normalModeFlushTimer}, chunks=${deliveredChunks.length}`);
         // 补发缓冲池中残留的文本（引擎未发送 final 帧时会走到这里）
         if (hasBufferedNormalModeText()) {
             try {
@@ -722,10 +743,10 @@ export async function processInboundMessage(api: any, msg: OneBotMessage): Promi
                 queueNormalModeFlush(() => flushBufferedNormalModeText(effectiveIsGroup, effectiveGroupId, uid));
                 await normalModeFlushChain;
             } catch (e: any) {
-                api.logger?.error?.(`[onebot] finally flush failed: ${e?.message ?? e}`);
+                traceLog.error(`finally flush failed: ${e?.message ?? e}`);
             }
         }
-        clearNormalModeFlushTimer();
+        clearNormalModeFlushTimer("finally");
         setForwardSuppressDelivery(false);
         setActiveReplySelfId(null);
         lastSentChunkCountBySession.delete(replySessionId);

--- a/src/handlers/process-inbound.ts
+++ b/src/handlers/process-inbound.ts
@@ -697,6 +697,9 @@ export async function processInboundMessage(api: any, msg: OneBotMessage): Promi
         });
     } catch (err: any) {
         await clearEmojiReaction();
+        // 异常时清空缓冲，避免 finally 补发半截正文后再发错误消息
+        normalModeBufferedText = "";
+        normalModeBufferedRawText = "";
         api.logger?.error?.(`[onebot] dispatch failed: ${err?.message}`);
         try {
             const { userId: uid, groupId: gid, isGroup: ig } = (ctxPayload as any)._onebot || {};
@@ -704,6 +707,20 @@ export async function processInboundMessage(api: any, msg: OneBotMessage): Promi
             else if (uid) await sendPrivateMsg(uid, `处理失败: ${err?.message?.slice(0, 80) || "未知错误"}`);
         } catch (_) { }
     } finally {
+        // 补发缓冲池中残留的文本（引擎未发送 final 帧时会走到这里）
+        if (hasBufferedNormalModeText()) {
+            try {
+                const { userId: uid, groupId: gid, isGroup: ig } = (ctxPayload as any)._onebot || {};
+                const sessionKey = String((ctxPayload as any).SessionKey ?? sessionId);
+                const groupMatch = sessionKey.match(/^onebot:group:(\d+)$/i);
+                const effectiveIsGroup = groupMatch != null || Boolean(ig);
+                const effectiveGroupId = (groupMatch ? parseInt(groupMatch[1], 10) : undefined) ?? gid;
+                queueNormalModeFlush(() => flushBufferedNormalModeText(effectiveIsGroup, effectiveGroupId, uid));
+                await normalModeFlushChain;
+            } catch (e: any) {
+                api.logger?.error?.(`[onebot] finally flush failed: ${e?.message ?? e}`);
+            }
+        }
         clearNormalModeFlushTimer();
         setForwardSuppressDelivery(false);
         setActiveReplySelfId(null);

--- a/src/handlers/process-inbound.ts
+++ b/src/handlers/process-inbound.ts
@@ -227,7 +227,11 @@ export async function processInboundMessage(api: any, msg: OneBotMessage): Promi
 
     const envelopeOptions = runtime.channel.reply?.resolveEnvelopeFormatOptions?.(cfg) ?? {};
     const chatType = isGroup ? "group" : "direct";
-    const fromLabel = String(userId);
+    // 优先使用群名片(card)，其次是昵称(nickname)，都没有则为空串
+    const senderNickname = (isGroup ? msg.sender?.card?.trim() : undefined)
+        || msg.sender?.nickname?.trim()
+        || "";
+    const fromLabel = senderNickname || String(userId);
 
     // 添加日志：打印插件接收到的原始消息内容
     api.logger?.info?.(`[onebot] received message from user ${userId}: "${messageText}"`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,11 @@ export interface OneBotMessage {
   raw_message?: string;
   self_id?: number;
   time?: number;
-  notice_type?: string;
+  sender?: {
+    user_id?: number;
+    nickname?: string;
+    card?: string;
+  };
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
- 为每条入站消息生成唯一 traceId，用于日志关联
- 记录 deliver 回调生命周期（入口、kind、chunk 计数）
- 追踪 normalModeFlushTimer 生命周期（schedule、trigger、clear 及原因）
- 新增 receivedFinal 标记，检测是否缺失 final 帧
- 在 catch/finally 块中记录状态快照（缓冲区、定时器、chunks）
- 增强 sendOneBotAction 的 echo 追踪、超时时打印 readyState、发送错误日志
- 将所有异常路径的 api.logger 替换为 traceLog 以保持 traceId 一致性"